### PR TITLE
fix(component): Prevent IE from throwing syntax errors

### DIFF
--- a/lib/StyleComponent.js
+++ b/lib/StyleComponent.js
@@ -1,7 +1,8 @@
 export default {
   name: 'svg2vue-style',
   functional: true,
-  render(h, ctx) {
+  // eslint-disable-next-line object-shorthand
+  render: function(h, ctx) {
     return h('style', ctx.data, ctx.children)
   }
 }


### PR DESCRIPTION
Object method shorthand is not supported in older browser. This should fix #20.